### PR TITLE
Migrate waypoint rendering to Laby World Objects

### DIFF
--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/Cubepanion.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/Cubepanion.java
@@ -24,6 +24,7 @@ import art.ameliah.laby.addons.cubepanion.core.listener.internal.InternalTracker
 import art.ameliah.laby.addons.cubepanion.core.listener.misc.MiscListeners;
 import art.ameliah.laby.addons.cubepanion.core.managers.CubepanionManager;
 import art.ameliah.laby.addons.cubepanion.core.managers.WidgetManager;
+import art.ameliah.laby.addons.cubepanion.core.render.waypoint.WaypointSubmitter;
 import art.ameliah.laby.addons.cubepanion.core.utils.AutoVoteProvider;
 import art.ameliah.laby.addons.cubepanion.core.utils.Colours;
 import art.ameliah.laby.addons.cubepanion.core.versionlinkers.ChestFinderLink;
@@ -120,6 +121,7 @@ public class Cubepanion extends LabyAddon<CubepanionConfig> {
     this.labyAPI().tagRegistry().register("level_tag", PositionType.RIGHT_TO_NAME, levelTag);
 
     WidgetManager.register(this);
+    WaypointSubmitter.registerWaypointSubmitter();
 
     log.info("Cubepanion has successfully registered all her components.");
   }

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/misc/ChestFinder.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/misc/ChestFinder.java
@@ -2,34 +2,15 @@ package art.ameliah.laby.addons.cubepanion.core.listener.misc;
 
 import art.ameliah.laby.addons.cubepanion.core.Cubepanion;
 import art.ameliah.laby.addons.cubepanion.core.config.QOLConfig;
-import art.ameliah.laby.addons.cubepanion.core.utils.Colours;
 import art.ameliah.laby.addons.cubepanion.core.utils.CubeGame;
 import art.ameliah.laby.addons.cubepanion.core.versionlinkers.ChestFinderLink;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
-import net.labymod.api.Laby;
-import net.labymod.api.client.component.Component;
-import net.labymod.api.client.gui.icon.Icon;
-import net.labymod.api.client.render.font.text.TextDrawMode;
-import net.labymod.api.client.resources.ResourceLocation;
-import net.labymod.api.event.Phase;
 import net.labymod.api.event.Subscribe;
 import net.labymod.api.event.client.chat.ChatReceiveEvent;
-import net.labymod.api.event.client.render.world.RenderWorldEvent;
-import net.labymod.api.laby3d.pipeline.RenderStates;
 import net.labymod.api.util.concurrent.task.Task;
 import org.jetbrains.annotations.NotNull;
 
 public class ChestFinder {
-
-  private static final Component CHEST_HOLOGRAM =
-      Component.translatable("cubepanion.hologram.chest_finder", Colours.Title);
-
-  private static final ResourceLocation CHEST_ITEM_TEXTURE =
-      ResourceLocation.create("minecraft", "textures/item/compass_00.png");
-
-  private static final Icon CHEST_ITEM_ICON =
-      Icon.texture(CHEST_ITEM_TEXTURE);
 
   private final Task task;
   private final QOLConfig config;
@@ -61,70 +42,6 @@ public class ChestFinder {
       Cubepanion.get().getChestFinderLink()
           .getLocations()
           .clear();
-    }
-
-  }
-
-  @Subscribe
-  public void onRenderWorld(RenderWorldEvent e) {
-
-    if (e.phase() != Phase.POST) {
-      return;
-    }
-
-    var link = Cubepanion.get().getChestFinderLink();
-    var chests = List.copyOf(link.getLocations());
-
-    if (chests.isEmpty()) {
-      return;
-    }
-
-    for (var chest : chests) {
-
-      var stack = e.stack();
-      var camera = e.camera();
-
-      var dx = chest.x() - camera.position().getX() + .5f;
-      var dy = chest.y() - camera.position().getY() + 1.5f;
-      var dz = chest.z() - camera.position().getZ() + .5f;
-
-      var distSq = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-      stack.push();
-      stack.translate(dx, dy, dz);
-
-      stack.rotate(camera.getYaw(), 0, -1, 0);
-      stack.rotate(camera.getPitch(), 1, 0, 0);
-
-      final var maxScale = .25f;
-      final var baseScale = .03f;
-      final var scale =
-          (float) Math.max(baseScale, Math.min(maxScale, distSq * .002));
-
-      stack.scale(-scale, -scale, scale);
-
-      final var iconSize = 16f;
-      final var iconX = -iconSize / 2f;
-      final var iconY = -18f;
-
-      CHEST_ITEM_ICON.render(
-          RenderStates.SEE_THROUGH_NAMETAG_ICON,
-          stack,
-          iconX,
-          iconY,
-          iconSize,
-          iconSize
-      );
-
-      Laby.references().componentRenderer().builder()
-          .text(CHEST_HOLOGRAM)
-          .centered(true)
-          .shadow(true)
-          .drawMode(TextDrawMode.SEE_THROUGH)
-          .render(stack);
-
-      stack.pop();
-
     }
 
   }

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/misc/ChestFinder.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/misc/ChestFinder.java
@@ -7,6 +7,7 @@ import art.ameliah.laby.addons.cubepanion.core.versionlinkers.ChestFinderLink;
 import java.util.concurrent.TimeUnit;
 import net.labymod.api.event.Subscribe;
 import net.labymod.api.event.client.chat.ChatReceiveEvent;
+import net.labymod.api.event.client.network.server.SubServerSwitchEvent;
 import net.labymod.api.util.concurrent.task.Task;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,10 +41,15 @@ public class ChestFinder {
       task.execute();
     } else if (message.contains(foundChestPart) && !message.contains(":")) {
       Cubepanion.get().getChestFinderLink()
-          .getLocations()
-          .clear();
+          .clearLocations();
     }
 
+  }
+
+  @Subscribe
+  public void onWorldChange(SubServerSwitchEvent e) {
+    Cubepanion.get().getChestFinderLink()
+        .clearLocations();
   }
 
 }

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/misc/ChestFinder.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/misc/ChestFinder.java
@@ -15,10 +15,11 @@ public class ChestFinder {
 
   private final Task task;
   private final QOLConfig config;
+  private final ChestFinderLink finderLink;
 
   public ChestFinder(Cubepanion addon, @NotNull ChestFinderLink link) {
     config = addon.configuration().getQolConfig();
-
+    finderLink = link;
     task = Task.builder(() -> {
       if (addon.getManager().getDivision().equals(CubeGame.LOBBY)) {
         link.displayLocations();
@@ -40,16 +41,14 @@ public class ChestFinder {
     if (message.equalsIgnoreCase(chestMessage)) {
       task.execute();
     } else if (message.contains(foundChestPart) && !message.contains(":")) {
-      Cubepanion.get().getChestFinderLink()
-          .clearLocations();
+      finderLink.clearLocations();
     }
 
   }
 
   @Subscribe
   public void onWorldChange(SubServerSwitchEvent e) {
-    Cubepanion.get().getChestFinderLink()
-        .clearLocations();
+    finderLink.clearLocations();
   }
 
 }

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointObject.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointObject.java
@@ -1,0 +1,33 @@
+package art.ameliah.laby.addons.cubepanion.core.render.waypoint;
+
+import static net.labymod.api.client.world.object.CullVolume.point;
+
+import net.labymod.api.client.component.Component;
+import net.labymod.api.client.gui.icon.Icon;
+import net.labymod.api.client.world.object.AbstractWorldObject;
+import net.labymod.api.client.world.object.CullVolume;
+import net.labymod.api.util.math.vector.DoubleVector3;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class WaypointObject extends AbstractWorldObject {
+
+  Icon icon;      // nullable
+  Component text; // nullable
+
+  public WaypointObject(
+      @NotNull DoubleVector3 position,
+      @Nullable Icon icon,
+      @Nullable Component text
+  ) {
+    super(position);
+    this.icon = icon;
+    this.text = text;
+  }
+
+  @Override
+  public @NotNull CullVolume cullVolume() {
+    return point(this.position());
+  }
+
+}

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointObject.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointObject.java
@@ -12,8 +12,11 @@ import org.jetbrains.annotations.Nullable;
 
 public class WaypointObject extends AbstractWorldObject {
 
-  Icon icon;      // nullable
-  Component text; // nullable
+  @Nullable
+  protected Icon icon;
+
+  @Nullable
+  protected Component text;
 
   public WaypointObject(
       @NotNull DoubleVector3 position,

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointObjectSnapshot.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointObjectSnapshot.java
@@ -1,0 +1,56 @@
+package art.ameliah.laby.addons.cubepanion.core.render.waypoint;
+
+import static net.labymod.api.laby3d.renderer.snapshot.Extras.empty;
+
+import net.labymod.api.client.component.Component;
+import net.labymod.api.client.gui.icon.Icon;
+import net.labymod.api.client.world.object.snapshot.AbstractWorldObjectSnapshot;
+import org.jetbrains.annotations.Nullable;
+
+public class WaypointObjectSnapshot extends AbstractWorldObjectSnapshot {
+
+  private final Icon icon;
+  private final Component text;
+
+  private final float cameraYaw;
+  private final float cameraPitch;
+  private final double distSq;
+
+  public WaypointObjectSnapshot(
+      double x, double y, double z,
+      int lightCoords,
+      @Nullable Icon icon,
+      @Nullable Component text,
+      float cameraYaw,
+      float cameraPitch,
+      double distSq
+  ) {
+    super(x, y, z, lightCoords, empty());
+    this.icon = icon;
+    this.text = text;
+    this.cameraYaw = cameraYaw;
+    this.cameraPitch = cameraPitch;
+    this.distSq = distSq;
+  }
+
+  public @Nullable Icon icon() {
+    return this.icon;
+  }
+
+  public @Nullable Component text() {
+    return this.text;
+  }
+
+  public float cameraYaw() {
+    return this.cameraYaw;
+  }
+
+  public float cameraPitch() {
+    return this.cameraPitch;
+  }
+
+  public double distSq() {
+    return this.distSq;
+  }
+
+}

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointSubmitter.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/render/waypoint/WaypointSubmitter.java
@@ -1,0 +1,98 @@
+package art.ameliah.laby.addons.cubepanion.core.render.waypoint;
+
+import static java.lang.Math.clamp;
+import static java.lang.Math.sqrt;
+import static net.labymod.api.client.gfx.pipeline.renderer.text.FontFlags.DISPLAY_MODE_SEE_THROUGH;
+import static net.labymod.api.client.gfx.pipeline.renderer.text.FontFlags.SHADOW;
+import static net.labymod.api.laby3d.render.queue.submissions.IconSubmission.DisplayMode.SEE_THROUGH;
+
+import net.labymod.api.Laby;
+import net.labymod.api.client.render.matrix.Stack;
+import net.labymod.api.client.render.state.world.CameraSnapshot;
+import net.labymod.api.client.world.object.submit.WorldObjectSubmitter;
+import net.labymod.api.laby3d.render.queue.SubmissionCollector;
+import org.jetbrains.annotations.NotNull;
+
+public class WaypointSubmitter extends WorldObjectSubmitter<WaypointObject, WaypointObjectSnapshot> {
+
+  private static final float SCALE_BASE = .03f;
+  private static final float SCALE_MAX = .25f;
+  private static final float SCALE_MODIFIER = .0035f;
+
+  private static final float ICON_SIZE = 16f;
+  private static final float ICON_Y_MOD = -18f;
+
+  @Override
+  public @NotNull WaypointObjectSnapshot createSnapshot(
+      @NotNull WaypointObject object,
+      double x, double y, double z,
+      int lightCoords,
+      @NotNull CameraSnapshot camera
+  ) {
+    return new WaypointObjectSnapshot(
+        x, y, z,
+        lightCoords,
+        object.icon,
+        object.text,
+        camera.getYaw(),
+        camera.getPitch(),
+        sqrt(x * x + y * y + z * z)
+    );
+  }
+
+  @Override
+  public void submit(
+      @NotNull Stack stack,
+      @NotNull SubmissionCollector collector,
+      @NotNull WaypointObjectSnapshot snapshot
+  ) {
+
+    stack.push();
+
+    stack.translate(snapshot.x(), snapshot.y(), snapshot.z());
+
+    stack.rotate(snapshot.cameraYaw(), 0, -1, 0);
+    stack.rotate(snapshot.cameraPitch(), 1, 0, 0);
+
+    final float scale = (float) clamp(snapshot.distSq() * SCALE_MODIFIER, SCALE_BASE, SCALE_MAX);
+
+    stack.scale(-scale, -scale, scale);
+
+    if (snapshot.icon() != null) {
+      final float iconX = -ICON_SIZE / 2f;
+      final float iconY = (snapshot.text() != null) ? ICON_Y_MOD : 0;
+      collector.submitIcon(
+          stack,
+          snapshot.icon(),
+          SEE_THROUGH,
+          iconX,
+          iconY,
+          ICON_SIZE,
+          ICON_SIZE,
+          0xFFFFFFFF
+      );
+    }
+
+    if (snapshot.text() != null) {
+      final float textX = -(Laby.references().componentRenderer().width(snapshot.text()) / 2);
+      collector.submitComponent(
+          stack,
+          snapshot.text(),
+          textX, 0f,
+          0xFFFFFFFF,
+          snapshot.lightCoords(),
+          0x00000000,
+          SHADOW | DISPLAY_MODE_SEE_THROUGH
+      );
+    }
+
+    stack.pop();
+
+  }
+
+  public static void registerWaypointSubmitter() {
+    Laby.references().worldObjectDispatcher()
+        .registerSubmitter(WaypointObject.class, new WaypointSubmitter());
+  }
+
+}

--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/versionlinkers/ChestFinderLink.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/versionlinkers/ChestFinderLink.java
@@ -1,21 +1,34 @@
 package art.ameliah.laby.addons.cubepanion.core.versionlinkers;
 
-
 import static art.ameliah.laby.addons.cubepanion.core.utils.Utils.chestLocationsComponent;
 
 import art.ameliah.laby.addons.cubepanion.core.Cubepanion;
 import art.ameliah.laby.addons.cubepanion.core.external.ChestLocation;
+import art.ameliah.laby.addons.cubepanion.core.render.waypoint.WaypointObject;
 import art.ameliah.laby.addons.cubepanion.core.utils.Colours;
 import java.util.ArrayList;
 import java.util.List;
+import net.labymod.api.Laby;
 import net.labymod.api.client.component.Component;
+import net.labymod.api.client.gui.icon.Icon;
+import net.labymod.api.client.resources.ResourceLocation;
 import net.labymod.api.reference.annotation.Referenceable;
+import net.labymod.api.util.math.vector.DoubleVector3;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Nullable
 @Referenceable
 public abstract class ChestFinderLink {
+
+  private static final Component CHEST_DISPLAY_COMPONENT =
+      Component.translatable("cubepanion.hologram.chest_finder", Colours.Title);
+
+  private static final ResourceLocation CHEST_DISPLAY_ICON_RESOURCE =
+      ResourceLocation.create("minecraft", "textures/item/compass_00.png");
+
+  private static final Icon CHEST_DISPLAY_ICON =
+      Icon.texture(CHEST_DISPLAY_ICON_RESOURCE);
 
   private static final Component NOT_FOUND =
       Component.translatable("cubepanion.messages.chests_finder.not_found", Colours.Error);
@@ -29,10 +42,23 @@ public abstract class ChestFinderLink {
     if (!chestLocations.isEmpty()) {
       for (ChestLocation loc : chestLocations) {
         Cubepanion.get().displayMessage(chestLocationsComponent(loc));
+        Laby.references().worldObjectRegistry()
+            .register(loc.toString(), new WaypointObject(
+                new DoubleVector3(loc.x() + .5, loc.y() + 1.5, loc.z() + .5),
+                CHEST_DISPLAY_ICON, CHEST_DISPLAY_COMPONENT
+            ));
       }
     } else {
       Cubepanion.get().displayMessage(NOT_FOUND);
     }
+  }
+
+  public void clearLocations() {
+    for (ChestLocation location : this.locations) {
+      Laby.references().worldObjectRegistry()
+          .unregister(location.toString());
+    }
+    this.locations.clear();
   }
 
   public @NotNull List<ChestLocation> getLocations() {

--- a/game-runner/src/v1_21_10/java/art/ameliah/laby/addons/cubepanion/v1_21_10/VersionedChestFinderLink.java
+++ b/game-runner/src/v1_21_10/java/art/ameliah/laby/addons/cubepanion/v1_21_10/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v1_21_11/java/art/ameliah/laby/addons/cubepanion/v1_21_11/VersionedChestFinderLink.java
+++ b/game-runner/src/v1_21_11/java/art/ameliah/laby/addons/cubepanion/v1_21_11/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v1_21_4/java/art/ameliah/laby/addons/cubepanion/v1_21_4/VersionedChestFinderLink.java
+++ b/game-runner/src/v1_21_4/java/art/ameliah/laby/addons/cubepanion/v1_21_4/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v1_21_5/java/art/ameliah/laby/addons/cubepanion/v1_21_5/VersionedChestFinderLink.java
+++ b/game-runner/src/v1_21_5/java/art/ameliah/laby/addons/cubepanion/v1_21_5/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v1_21_8/java/art/ameliah/laby/addons/cubepanion/v1_21_8/VersionedChestFinderLink.java
+++ b/game-runner/src/v1_21_8/java/art/ameliah/laby/addons/cubepanion/v1_21_8/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v1_21_9/java/art/ameliah/laby/addons/cubepanion/v1_21_9/VersionedChestFinderLink.java
+++ b/game-runner/src/v1_21_9/java/art/ameliah/laby/addons/cubepanion/v1_21_9/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v26_1/java/art/ameliah/laby/addons/cubepanion/v26_1/VersionedChestFinderLink.java
+++ b/game-runner/src/v26_1/java/art/ameliah/laby/addons/cubepanion/v26_1/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v26_1_1/java/art/ameliah/laby/addons/cubepanion/v26_1_1/VersionedChestFinderLink.java
+++ b/game-runner/src/v26_1_1/java/art/ameliah/laby/addons/cubepanion/v26_1_1/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();

--- a/game-runner/src/v26_1_2/java/art/ameliah/laby/addons/cubepanion/v26_1_2/VersionedChestFinderLink.java
+++ b/game-runner/src/v26_1_2/java/art/ameliah/laby/addons/cubepanion/v26_1_2/VersionedChestFinderLink.java
@@ -26,7 +26,7 @@ public class VersionedChestFinderLink extends ChestFinderLink {
   @Override
   public @NotNull List<ChestLocation> getChestLocations() {
 
-    this.locations.clear();
+    this.clearLocations();
 
     LocalPlayer player = Minecraft.getInstance().player;
     ClientPacketListener con = Minecraft.getInstance().getConnection();


### PR DESCRIPTION
Hi, I've migrated waypoint rendering to Laby World Objects.
Basically this change is to make "rendering api" which will be for future features, because of that I created package `X.render` where anything related to rendering will be placed.

After my exams maybe I'll do some skyblock related features such as dungeon minimap for example.
_(currently I don't know how skyblock looks like, so I can't predict anything)_

This pull request also fixes bug which I encountered on 26.1.x:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/99148038-fa43-4088-b38f-15100d42e09c" />

Have a nice day!
