### PR TITLE
Added missing `sendPartyInfoCommand#execute` call in party listener.

### DIFF
--- a/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/internal/Party.java
+++ b/core/src/main/java/art/ameliah/laby/addons/cubepanion/core/listener/internal/Party.java
@@ -150,7 +150,7 @@ public class Party {
 
   private void toggleTryingToReadPartyMembers() {
     this.tryingToReadPartyMembers = true;
-
+    this.sendPartyInfoCommand.execute();
   }
 
 }


### PR DESCRIPTION
Before changes made in [2ff591f Massive rewrite](https://github.com/Fesaa/Cubepanion/commit/2ff591fb76120c94da1f801016b9f18d36cebffe), calling  the `Party#toggleTryingToReadPartyMembers` function would invoke `/party info` command. Commit `2ff591f` replaced this with a dummy task implementing the same logic, but it was never executed.

Because of that, if player sent a message in global chat that matched the regex, that message was ignored because `tryingToReadPartyMembers` was still set to true.